### PR TITLE
Updating slack invite links.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,12 +3,12 @@ We happily welcome contributions to Delta Lake. We use [GitHub Issues](/../../is
 # Governance
 Delta Lake is an independent open-source project and not controlled by any single company. To emphasize this we joined the [Delta Lake Project](https://community.linuxfoundation.org/delta-lake/) in 2019, which is a sub-project of the Linux Foundation Projects. Within the project, we make decisions based on [these rules](https://delta.io/pdfs/delta-charter.pdf).
 
-Delta Lake is supported by a wide set of developers from over 50 organizations across multiple repositories.  Since 2019, more than 190 developers have contributed to Delta Lake!  The Delta Lake community is growing by leaps and bounds with more than 6000 members in the [Delta Users slack](https://dbricks.co/delta-users-slack)).
+Delta Lake is supported by a wide set of developers from over 50 organizations across multiple repositories.  Since 2019, more than 190 developers have contributed to Delta Lake!  The Delta Lake community is growing by leaps and bounds with more than 6000 members in the [Delta Users slack](https://go.delta.io/slack)).
 
 For more information, please refer to the [founding technical charter](https://delta.io/pdfs/delta-charter.pdf).
 
 # Communication
-- Before starting work on a major feature, please reach out to us via [GitHub](https://github.com/delta-io/delta/issues), [Slack](https://go.delta.io/delta-users), [email](https://groups.google.com/g/delta-users), etc. We will make sure no one else is already working on it and ask you to open a GitHub issue.
+- Before starting work on a major feature, please reach out to us via [GitHub](https://github.com/delta-io/delta/issues), [Slack](https://go.delta.io/slack), [email](https://groups.google.com/g/delta-users), etc. We will make sure no one else is already working on it and ask you to open a GitHub issue.
 - A "major feature" is defined as any change that is > 100 LOC altered (not including tests), or changes any user-facing behavior.
 - We will use the GitHub issue to discuss the feature and come to agreement.
 - This is to prevent your time being wasted, as well as ours.


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://github.com/delta-io/delta/blob/master/CONTRIBUTING.md
  2. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP] Your PR title ...'.
  3. Be sure to keep the PR description updated to reflect all changes.
  4. Please write your PR title to summarize what this PR proposes.
  5. If possible, provide a concise example to reproduce the issue for a faster review.
  6. If applicable, include the corresponding issue number in the PR title and link it in the body.
-->

## Description
The current Slack invite has expired, updating it to a bit.ly link that is updated regularly. Also see #1270.

<!--
- Describe what this PR changes.
- Describe why we need the change.
 
If this PR resolves an issue be sure to include "Resolves #XXX" to correctly link and close the issue upon merge.
-->

## How was this patch tested?
Verified that it works for any user and goes to the current Slack invite


<!--
If tests were added, say they were added here. Please make sure to test the changes thoroughly including negative and positive cases if possible.
If the changes were tested in any way other than unit tests, please clarify how you tested step by step (ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future).
If the changes were not tested, please explain why.
-->

## Does this PR introduce _any_ user-facing changes?
No
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Delta Lake versions or within the unreleased branches such as master.
If no, write 'No'.
-->
